### PR TITLE
solving migration problem

### DIFF
--- a/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/20250324213701_locationAndBranchesModule.Designer.cs
+++ b/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/20250324213701_locationAndBranchesModule.Designer.cs
@@ -12,7 +12,7 @@ using Shipping.Repository.Data;
 namespace Shipping.Repository.Data.Migrations
 {
     [DbContext(typeof(ShippingContext))]
-    [Migration("20250323215815_locationAndBranchesModule")]
+    [Migration("20250324213701_locationAndBranchesModule")]
     partial class locationAndBranchesModule
     {
         /// <inheritdoc />
@@ -293,6 +293,9 @@ namespace Shipping.Repository.Data.Migrations
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("BranchId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Id")
                         .HasColumnType("int");
 
                     b.Property<bool>("IsDefault")

--- a/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/20250324213701_locationAndBranchesModule.cs
+++ b/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/20250324213701_locationAndBranchesModule.cs
@@ -56,7 +56,8 @@ namespace Shipping.Repository.Data.Migrations
                 {
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     BranchId = table.Column<int>(type: "int", nullable: false),
-                    IsDefault = table.Column<bool>(type: "bit", nullable: false)
+                    IsDefault = table.Column<bool>(type: "bit", nullable: false),
+                    Id = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/ShippingContextModelSnapshot.cs
+++ b/Shipping_Mnagement_System/Shipping.Repository/Data/Migrations/ShippingContextModelSnapshot.cs
@@ -292,6 +292,9 @@ namespace Shipping.Repository.Data.Migrations
                     b.Property<int>("BranchId")
                         .HasColumnType("int");
 
+                    b.Property<int>("Id")
+                        .HasColumnType("int");
+
                     b.Property<bool>("IsDefault")
                         .HasColumnType("bit");
 


### PR DESCRIPTION
While working on the database migrations for the Shipping Management System, an issue arose due to the presence of an incorrect migration. The migration testBranchTable was created after locationAndBranchesModule, but we wanted to keep only locationAndBranchesModule with the correct schema changes. Additionally, attempting to apply the locationAndBranchesModule migration resulted in a "Pending Model Changes Warning", which prevented updating the database without adding a new migration.